### PR TITLE
Fix country name

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -229,7 +229,7 @@
     "TR": "Turkey",
     "TT": "Trinidad and Tobago",
     "TV": "Tuvalu",
-    "TW": "Taiwan, Province of China",
+    "TW": "Taiwan, Republic of China",
     "TZ": "Tanzania, United Republic of",
     "UA": "Ukraine",
     "UG": "Uganda",


### PR DESCRIPTION
Also see: wikipedia [page](https://en.wikipedia.org/wiki/Taiwan).

Or just Taiwan, if you don't want to get into political disputes...