### PR TITLE
fi.svg add missing viewBox attribute

### DIFF
--- a/svg/fi.svg
+++ b/svg/fi.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1800" height="1100">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1800 1100" width="1800" height="1100">
 <rect width="1800" height="1100" fill="#fff"/>
 <rect width="1800" height="300" y="400" fill="#003580"/>
 <rect width="300" height="1100" x="500" fill="#003580"/>


### PR DESCRIPTION
For IE 11, if a SVG doesn't have viewBox, it cannot be properly resized.