### PR TITLE
Remove the extra trailing space in a fill value in lu.svg

### DIFF
--- a/svg/lu.svg
+++ b/svg/lu.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 600">
-<rect width="1000" height="300" y="300" fill="#00A1DE "/>
+<rect width="1000" height="300" y="300" fill="#00a1de"/>
 <rect width="1000" height="300" fill="#ed2939"/>
 <rect width="1000" height="200" y="200" fill="#fff"/>
 </svg>


### PR DESCRIPTION
Removed an extra trailing space in a fill value of Luxembourg flag. @hjnilsson 